### PR TITLE
Adicionando métodos faltantes ao CRUD da biblioteca de peixes

### DIFF
--- a/src/controllers/fishWikiController.ts
+++ b/src/controllers/fishWikiController.ts
@@ -114,4 +114,65 @@ export default class FishController {
       });
     }
   };
+
+  deleteFish = async (req: Request, res: Response) => {
+    try {
+      const fishWikiRepository = connection.getRepository(FishWiki);
+
+      const fishId = req.params.id;
+      const fishWiki = await fishWikiRepository.findOne({
+        where: { id: fishId },
+      });
+
+      if (!fishWiki) {
+        return res.status(404).json({
+          message: 'Peixe não encontrado',
+        });
+      }
+
+      await fishWikiRepository.createQueryBuilder("fishWiki")
+      .delete()
+      .where("id = :id", {id: fishId})
+      .execute();
+
+      return res.status(200).json(fishWiki);
+
+    } catch (error) {
+      return res.status(500).json({
+        message: 'Falha ao processar requisição',
+      });
+    }
+  }
+
+  updateFish = async (req: Request, res: Response) => {
+    try {
+      const fishWikiRepository = connection.getRepository(FishWiki);
+
+      const fishId = req.params.id;
+
+      const fishWiki = await fishWikiRepository.findOne({
+        where: { id: fishId },
+      });
+
+      if (!fishWiki) {
+        return res.status(404).json({
+          message: 'Peixe não encontrado',
+        });
+      }
+
+      await fishWikiRepository.createQueryBuilder("fishWiki")
+      .update()
+      .set({...req.body})
+      .where("id = :id", {id: fishId})
+      .execute();
+
+      return res.status(200).json({...fishWiki, ...req.body});
+
+    } catch (error) {
+      return res.status(500).json({
+        message: 'Falha ao processar requisição',
+      });
+    }
+  }
+
 }

--- a/src/routes/fishRoutes.ts
+++ b/src/routes/fishRoutes.ts
@@ -17,4 +17,12 @@ fishWikiRoutes.get('/:id', (req: Request, res: Response) => {
   fishWikiController.getOneFishWiki(req, res);
 });
 
+fishWikiRoutes.delete('/:id', (req: Request, res: Response) => {
+  fishWikiController.deleteFish(req, res);
+});
+
+fishWikiRoutes.patch('/:id', (req: Request, res: Response) => {
+  fishWikiController.updateFish(req, res);
+});
+
 export default fishWikiRoutes;

--- a/test/routes/wikiController.spec.ts
+++ b/test/routes/wikiController.spec.ts
@@ -241,3 +241,123 @@ describe('Test Get One Wiki function', () => {
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });
+
+describe('Test Delete Fish', () => {
+  it('should delete an exist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      delete: ()  => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => [wikiMock],
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should return 404 when try to delete an unexist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => (false));
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('should return 500', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      delete: ()  => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => { throw new Error },
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+})
+
+describe('Test Update Fish', () => {
+  it('should update an exist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      update: ()  => createQueryBuilder,
+      set: () => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => [wikiMock],
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    mockReq.body = {
+      food: "new food"
+    }
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should return 404 when try to update an unexist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => (false));
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('should return 500', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      update: ()  => createQueryBuilder,
+      set: () => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => { throw new Error },
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+})


### PR DESCRIPTION
# Gerenciar biblioteca de peixes

# Descrição

Adicionar métodos PATCH e DELETE para finalizar o CRUD da biblioteca de peixes

# Issue Relacionada

[#92](https://github.com/fga-eps-mds/2022-2-EuPescador-Doc/issues/92)

# Tipos de mudança

- [x] Adicionar método PATCH para atualizar os dados de um peixe
- [x] Adicionar método DELETE para remover um peixe

