### PR TITLE
#92 Adicionando métodos faltantes ao CRUD da biblioteca de peixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@types/cors": "^2.8.12",
     "@types/jsonwebtoken": "^8.5.5",
+    "axios": "^1.2.1",
     "bcryptjs": "^2.4.3",
     "convert-excel-to-json": "^1.7.0",
     "cors": "^2.8.5",
@@ -64,7 +65,7 @@
     "reflect-metadata": "^0.1.13",
     "request": "^2.88.2",
     "supertest": "^6.1.6",
-    "uuid": "^9.0.0",
-    "typeorm": "^0.3.6"
+    "typeorm": "^0.3.6",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/controllers/fishWikiController.ts
+++ b/src/controllers/fishWikiController.ts
@@ -114,4 +114,65 @@ export default class FishController {
       });
     }
   };
+
+  deleteFish = async (req: Request, res: Response) => {
+    try {
+      const fishWikiRepository = connection.getRepository(FishWiki);
+
+      const fishId = req.params.id;
+      const fishWiki = await fishWikiRepository.findOne({
+        where: { id: fishId },
+      });
+
+      if (!fishWiki) {
+        return res.status(404).json({
+          message: 'Peixe não encontrado',
+        });
+      }
+
+      await fishWikiRepository.createQueryBuilder("fishWiki")
+      .delete()
+      .where("id = :id", {id: fishId})
+      .execute();
+
+      return res.status(200).json(fishWiki);
+
+    } catch (error) {
+      return res.status(500).json({
+        message: 'Falha ao processar requisição',
+      });
+    }
+  }
+
+  updateFish = async (req: Request, res: Response) => {
+    try {
+      const fishWikiRepository = connection.getRepository(FishWiki);
+
+      const fishId = req.params.id;
+
+      const fishWiki = await fishWikiRepository.findOne({
+        where: { id: fishId },
+      });
+
+      if (!fishWiki) {
+        return res.status(404).json({
+          message: 'Peixe não encontrado',
+        });
+      }
+
+      await fishWikiRepository.createQueryBuilder("fishWiki")
+      .update()
+      .set({...req.body})
+      .where("id = :id", {id: fishId})
+      .execute();
+
+      return res.status(200).json({...fishWiki, ...req.body});
+
+    } catch (error) {
+      return res.status(500).json({
+        message: 'Falha ao processar requisição',
+      });
+    }
+  }
+
 }

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express';
+import { decode } from 'jsonwebtoken';
+
+import axios from 'axios';
+
+interface Idata {
+  id: string;
+  admin: boolean;
+  superAdmin: boolean;
+}
+
+export default class AuthService {
+  decodeToken = async (token: string) => {
+    const decodeToken = decode(token) as Idata;
+    
+    return decodeToken;
+  };
+
+  authorize = async (req: Request, res: Response, next: () => void) => {
+    const token = req.headers.authorization;
+    try {
+      await axios.get(String(`${process.env.USER_API_URL}/authToken`), {
+        headers: {
+          Accept: 'application/json',
+          authorization: token,
+        },
+      });
+      const decodeToken = await this.decodeToken(String(token?.split(':')[1].trim()));
+      if(!decodeToken.admin) {
+        return res.status(401).json({"message": "usuário não autorizado"})
+      }
+      console.log("decodeToken: ", decodeToken);
+      next();
+    } catch (error: any) {
+      if (error.response) {
+        const { response } = error;
+        res.status(response.status).json(response.data);
+      }
+
+      res.status(500).json({ message: 'User API not found' });
+    }
+  };
+}

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -12,7 +12,6 @@ interface Idata {
 export default class AuthService {
   decodeToken = async (token: string) => {
     const decodeToken = decode(token) as Idata;
-    
     return decodeToken;
   };
 
@@ -27,9 +26,8 @@ export default class AuthService {
       });
       const decodeToken = await this.decodeToken(String(token?.split(':')[1].trim()));
       if(!decodeToken.admin) {
-        return res.status(401).json({"message": "usuário não autorizado"})
+        res.status(401).json({"message": "usuário não autorizado"});
       }
-      console.log("decodeToken: ", decodeToken);
       next();
     } catch (error: any) {
       if (error.response) {

--- a/src/routes/fishRoutes.ts
+++ b/src/routes/fishRoutes.ts
@@ -1,7 +1,11 @@
 import { Request, Response, Router } from 'express';
 import FishController from '../controllers/fishWikiController';
 
+import AuthService from '../middlewares/auth';
+
 const fishWikiRoutes = Router();
+
+const authService = new AuthService();
 
 const fishWikiController = new FishController();
 
@@ -17,11 +21,11 @@ fishWikiRoutes.get('/:id', (req: Request, res: Response) => {
   fishWikiController.getOneFishWiki(req, res);
 });
 
-fishWikiRoutes.delete('/:id', (req: Request, res: Response) => {
+fishWikiRoutes.delete('/:id', authService.authorize, (req: Request, res: Response) => {
   fishWikiController.deleteFish(req, res);
 });
 
-fishWikiRoutes.patch('/:id', (req: Request, res: Response) => {
+fishWikiRoutes.patch('/:id', authService.authorize, (req: Request, res: Response) => {
   fishWikiController.updateFish(req, res);
 });
 

--- a/src/routes/fishRoutes.ts
+++ b/src/routes/fishRoutes.ts
@@ -17,4 +17,12 @@ fishWikiRoutes.get('/:id', (req: Request, res: Response) => {
   fishWikiController.getOneFishWiki(req, res);
 });
 
+fishWikiRoutes.delete('/:id', (req: Request, res: Response) => {
+  fishWikiController.deleteFish(req, res);
+});
+
+fishWikiRoutes.patch('/:id', (req: Request, res: Response) => {
+  fishWikiController.updateFish(req, res);
+});
+
 export default fishWikiRoutes;

--- a/test/routes/wikiController.spec.ts
+++ b/test/routes/wikiController.spec.ts
@@ -142,10 +142,10 @@ describe('Test create Wiki function', () => {
     const response = mockResponse();
     const fishWikiRepository = connection.getRepository(FishWiki);
 
-    fishWikiRepository.find = jest
+    fishWikiRepository.save = jest
       .fn()
-      .mockImplementationOnce(() => Promise.reject(Error('Request Failure')));
-    const res = await wikiController.getAllFish(mockRequestDefault, response);
+      .mockImplementationOnce(() => { throw new Error });
+    const res = await wikiController.createFish(mockRequestDefault, response);
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });

--- a/test/routes/wikiController.spec.ts
+++ b/test/routes/wikiController.spec.ts
@@ -241,3 +241,123 @@ describe('Test Get One Wiki function', () => {
     expect(res.status).toHaveBeenCalledWith(500);
   });
 });
+
+describe('Test Delete Fish', () => {
+  it('should delete an exist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      delete: ()  => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => [wikiMock],
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should return 404 when try to delete an unexist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => (false));
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('should return 500', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      delete: ()  => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => { throw new Error },
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.deleteFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+})
+
+describe('Test Update Fish', () => {
+  it('should update an exist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      update: ()  => createQueryBuilder,
+      set: () => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => [wikiMock],
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    mockReq.body = {
+      food: "new food"
+    }
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should return 404 when try to update an unexist fish', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => (false));
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('should return 500', async () => {
+    const response = mockResponse();
+    const fishWikiRepository = connection.getRepository(FishWiki);
+
+    fishWikiRepository.findOne = jest.fn().mockImplementationOnce(() => ({
+      select: jest.fn().mockResolvedValueOnce([wikiMock]),
+    }));
+
+    const createQueryBuilder: any = {
+      update: ()  => createQueryBuilder,
+      set: () => createQueryBuilder,
+      where: () => createQueryBuilder,
+      execute: () => { throw new Error },
+    };
+
+    jest
+    .spyOn(connection.getRepository(FishWiki), 'createQueryBuilder')
+    .mockImplementation(() => createQueryBuilder);
+
+    const res = await wikiController.updateFish(mockReq, response);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+})


### PR DESCRIPTION
# Gerenciar biblioteca de peixes

# Descrição

Adicionar métodos PATCH e DELETE para finalizar o CRUD da biblioteca de peixes

# Issue Relacionada

[#92](https://github.com/fga-eps-mds/2022-2-EuPescador-Doc/issues/92)

# Tipos de mudança

- [x] Adicionar método PATCH para atualizar os dados de um peixe
- [x] Adicionar método DELETE para remover um peixe